### PR TITLE
About page and custom 404 and 500 error pages

### DIFF
--- a/isthisatroll/urls.py
+++ b/isthisatroll/urls.py
@@ -23,3 +23,6 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('user/', include('user.urls')),
 ]
+
+handler404 = 'user.views.page_not_found'
+handler500 = 'user.views.server_error'

--- a/isthisatroll/urls.py
+++ b/isthisatroll/urls.py
@@ -15,6 +15,7 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import include, path
+from django.views.generic import TemplateView
 
 from user.views import SearchView
 
@@ -22,6 +23,7 @@ urlpatterns = [
     path('', SearchView.as_view(), name="home"),
     path('admin/', admin.site.urls),
     path('user/', include('user.urls')),
+    path('about/', TemplateView.as_view(template_name='about.html'))
 ]
 
 handler404 = 'user.views.page_not_found'

--- a/isthisatroll/urls.py
+++ b/isthisatroll/urls.py
@@ -20,10 +20,10 @@ from django.views.generic import TemplateView
 from user.views import SearchView
 
 urlpatterns = [
-    path('', SearchView.as_view(), name="home"),
+    path('', SearchView.as_view(), name='home'),
     path('admin/', admin.site.urls),
     path('user/', include('user.urls')),
-    path('about/', TemplateView.as_view(template_name='about.html'))
+    path('about/', TemplateView.as_view(template_name='about.html'), name='about')
 ]
 
 handler404 = 'user.views.page_not_found'

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -9,3 +9,17 @@ html, body {
 body {
   background-color: #f5f5f5;
 }
+
+/*
+Style for large text blocks
+*/
+.text-block {
+  width: 50%;
+}
+
+/* sets a larger width if the screen is small (in width), for phones */
+@media (max-width: 800px) {
+  .text-block {
+    width: 80%;
+  }
+}

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="container bg-light rounded mx-auto">
+  <div class="row">
+    <h1 class="display-4 pt-5"><tt> 404 :( </tt></h1>
+  </div>
+  <div class="row">
+    <h2 class="pb-5"><tt> Page not found </tt></h2>
+  </div>
+  <div class="row">
+    <a href="{% url 'home' %}" class="text-center mb-3 text-muted"> Let's go back home </a>
+  </div>
+</div>
+{% endblock content %}

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,5 +1,9 @@
 {% extends "base.html" %}
 
+{% block title %}
+  - Page not found
+{% endblock title %}
+
 {% block content %}
 <div class="container bg-light rounded mx-auto">
   <div class="row">

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,5 +1,9 @@
 {% extends "base.html" %}
 
+{% block title %}
+  - Server error
+{% endblock title %}
+
 {% block content %}
 <div class="container bg-light rounded mx-auto">
   <div class="row">

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="container bg-light rounded mx-auto">
+  <div class="row">
+    <h1 class="display-4 pt-5"><tt> 500 :( </tt></h1>
+  </div>
+  <div class="row">
+    <h2><tt> Server error </tt></h2>
+  </div>
+  <div class="row">
+    <tt class="pb-5"> The admins have been notified. </tt>
+  </div>
+  <div class="row">
+    <a href="{% url 'home' %}" class="text-center mb-3 text-muted"> Let's go back home </a>
+  </div>
+</div>
+{% endblock content %}

--- a/templates/about.html
+++ b/templates/about.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% block title %}
+  - About
+{% endblock title %}
+
+{% block content %}
+<div class="container bg-light rounded mx-auto p-3 text-block">
+  <div class="row mb-3">
+    <div class="col-7 text-right">
+      <h1> About </h1>
+    </div>
+    <div class="col-5 my-auto text-muted">
+      <a class="nav-link text-muted my-auto" target="_blank" href="https://github.com/70AdmiralString">70AdmiralString</a>
+    </div>
+  </div>
+  <div class="row px-2">
+    Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+  </div>
+</div>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -34,6 +34,9 @@
               <a class="nav-link active text-dark h5" href="{% url 'home' %}">IsThisATroll?</a>
             </li>
             <li class="nav-item">
+              <a class="nav-link active text-muted my-auto" href="{% url 'about' %}">About</a>
+            </li>
+            <li class="nav-item">
               <a class="nav-link active text-muted my-auto" target="_blank" href="https://github.com/70AdmiralString">70AdmiralString</a>
             </li>
           </ul>

--- a/user/static/user/css/detail.css
+++ b/user/static/user/css/detail.css
@@ -1,4 +1,10 @@
 /*
+WARNING
+This stylesheet is deprecated: there is no #redditor-analysis id anymore.
+The functionalities of this stylesheet have been moved to the base stylesheet.
+The abovementioned id has been replaced by the class .text-block to make it
+useful for other items too (see e.g. the about page).
+
 Style for the redditor_detail template (redditor_detail.html).
 */
 

--- a/user/templates/user/redditor_detail.html
+++ b/user/templates/user/redditor_detail.html
@@ -2,25 +2,18 @@
 
 {% load static %}
 
-{% block header %}
-  <link rel="stylesheet" type="text/css" href="{% static 'user/css/detail.css' %}">
-{% endblock header %}
-
 {% block title %} - {{ form.username.initial }}{% endblock title %}
 
 {% block content %}
-  <div id="redditor-analysis" class="container mx-auto bg-light rounded">
+  <div class="container mx-auto bg-light rounded text-block">
     <div class="container p-3">
       <div class="row mb-3">
         <div class="col-7 text-right">
           <h1> {{ redditor.username }} </h1>
         </div>
-        <div class="col-5 my-auto text-muted small text-left">
+        <div class="col-5 my-auto text-muted small">
           {{ redditor.analysis_date }}
         </div>
-      </div>
-      <div class="row">
-
       </div>
       <div class="row">
         It is a troll with likelihood {{ redditor.result }} %.

--- a/user/views.py
+++ b/user/views.py
@@ -48,3 +48,17 @@ class SearchView(generic.edit.FormView):
                                     result=0.1)
             new_redditor.save()
         return HttpResponseRedirect(reverse('user:detail', args=(username,)))
+
+
+def page_not_found(request, exception):
+    """View for error 404."""
+    response = render(request, '404.html')
+    response.status_code = 404
+    return response
+
+
+def server_error(request):
+    """View for error 500."""
+    response = render(request, '500.html')
+    response.status_code = 500
+    return response


### PR DESCRIPTION
Closes #18 and closes #20

### Details
- Implements an about page
- Implements custom 404 and 500 error pages
- Moves the functionality of `detail.css` to `base.css`, replacing the `#redditor-analysis` id with the `.text-block` class